### PR TITLE
Reduce past event visibility in search result

### DIFF
--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -74,7 +74,7 @@ block main
       h2(class="max-md:text-center text-3xl md:text-4xl font-bold mb-8" data-i18n="index.t5") 歷年活動
       div(class="grid md:grid-cols-3 gap-4")
         mixin pastEvent(year)
-          - var title = "g0v Summit " + year
+          - var title = "past-" + year
           a(href="https://summit.g0v.tw/"+year target="_blank" title=title class="relative group border border-neutral-200")
             img(class="w-full" src=`assets/img/past_events/${year}.jpg` alt=title)
             div(class="absolute inset-0 bg-primary/80 opacity-0 group-hover:opacity-100 transition-all text-white font-bold flex items-center justify-center")


### PR DESCRIPTION
Fix #21 

目前搜尋 g0v summit 2026，搜尋結果會隨機出現舊活動縮圖，應該是來自"歷年活動"區域

這個 PR 修改歷年活動 img alt，取消使用 "g0v summit [年份]" 文字，避免搜尋結果出現舊活動縮圖