### PR TITLE
新增客語翻譯版本

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig({
   },
   i18n: {
     defaultLocale: 'zh-tw',
-    locales: ['zh-tw', 'en'],
+    locales: ['zh-tw', 'en', 'hak-tw'],
   },
   devToolbar: {
     enabled: false,

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -147,11 +147,14 @@ const navs: NavItem[] = [
         class="pointer-events-none absolute top-0 right-0 bottom-0 left-0 z-60 block w-max transform-[translateY(90%)] opacity-0 transition-[opacity,transform] group-hover:pointer-events-auto group-hover:transform-[translateY(100%)] group-hover:opacity-100"
       >
         <div class="lang-btn-group mt-1 flex flex-col">
-          <button data-target={getRelativeLocaleUrl('zh-tw', pathname)} class="w-full cursor-pointer bg-black px-6 py-2 text-left text-white transition-[background-color] hover:bg-neutral-500"
+          <button lang="zh-TW" data-target={getRelativeLocaleUrl('zh-tw', pathname)} class="w-full cursor-pointer bg-black px-6 py-2 text-left text-white transition-[background-color] hover:bg-neutral-500"
             >華語</button
           >
-          <button data-target={getRelativeLocaleUrl('en', pathname)} class="w-full cursor-pointer bg-black px-6 py-2 text-left text-white transition-[background-color] hover:bg-neutral-500"
+          <button lang="en" data-target={getRelativeLocaleUrl('en', pathname)} class="w-full cursor-pointer bg-black px-6 py-2 text-left text-white transition-[background-color] hover:bg-neutral-500"
             >English</button
+          >
+          <button lang="hak-TW" data-target={getRelativeLocaleUrl('hak-tw', pathname)} class="w-full cursor-pointer bg-black px-6 py-2 text-left text-white transition-[background-color] hover:bg-neutral-500"
+            >客話</button
           >
         </div>
       </div>

--- a/src/components/agenda/CTSession.astro
+++ b/src/components/agenda/CTSession.astro
@@ -1,6 +1,6 @@
 ---
 import { getRelativeLocaleUrl } from 'astro:i18n'
-import { getLocaleFromPath, useI18n } from '~/i18n/utils'
+import { getLocaleFromPath, useI18n, isMandarinPreferred } from '~/i18n/utils'
 import { formatHHmm, formatMMdd } from '~/utils/datetime'
 import { hrefForAgendaSession } from '~/utils/build/agenda/hrefForAgendaSession'
 import Markdown from '~/components/Markdown.astro'
@@ -12,7 +12,7 @@ import { ctColorMap } from './ctColorMap'
 
 const { t } = useI18n(Astro.url.pathname)
 const locale = getLocaleFromPath(Astro.url.pathname)
-const isZhTW = locale === 'zh-tw'
+const isZhTW = isMandarinPreferred(locale)
 const { ctSession } = Astro.props
 
 const sessionTitle = isZhTW ? ctSession.zh.title : ctSession.en.title || ctSession.zh.title

--- a/src/components/agenda/Session.astro
+++ b/src/components/agenda/Session.astro
@@ -1,7 +1,7 @@
 ---
 import Markdown from '~/components/Markdown.astro'
 import schedule from '~/data/schedule.json'
-import { getLocaleFromPath, useI18n } from '~/i18n/utils'
+import { getLocaleFromPath, useI18n, isMandarinPreferred } from '~/i18n/utils'
 import { getRelativeLocaleUrl } from 'astro:i18n'
 import { formatHHmm, formatMMdd } from '~/utils/datetime'
 import { getLocalizedSpeakerName, getAvatar, isDefaultAvatar } from '~/utils/build/speaker'
@@ -10,7 +10,7 @@ import AvatarImage from '~/components/AvatarImage.astro'
 
 const { t } = useI18n(Astro.url.pathname)
 const locale = getLocaleFromPath(Astro.url.pathname)
-const isZhTW = locale === 'zh-tw'
+const isZhTW = isMandarinPreferred(locale)
 
 const { session } = Astro.props
 const sessionTitle = isZhTW ? session.zh.title : session.en.title || session.zh.title

--- a/src/components/agenda/SessionBadges.astro
+++ b/src/components/agenda/SessionBadges.astro
@@ -1,13 +1,13 @@
 ---
 import { ctColorMap } from './ctColorMap'
 import { hrefForAgendaSession } from '~/utils/build/agenda/hrefForAgendaSession'
-import { getLocaleFromPath, useI18n } from '~/i18n/utils'
+import { getLocaleFromPath, useI18n, isMandarinPreferred } from '~/i18n/utils'
 import schedule from '~/data/schedule.json'
 import Badge from '~/components/agenda/Badge.astro'
 
 const { t } = useI18n(Astro.url.pathname)
 const locale = getLocaleFromPath(Astro.url.pathname)
-const isZhTW = locale === 'zh-tw'
+const isZhTW = isMandarinPreferred(locale)
 
 const { session } = Astro.props
 

--- a/src/components/speaker/SpeakerGridCard.astro
+++ b/src/components/speaker/SpeakerGridCard.astro
@@ -1,6 +1,6 @@
 ---
 import Markdown from '~/components/Markdown.astro'
-import { getLocaleFromPath } from '~/i18n/utils'
+import { getLocaleFromPath, isMandarinPreferred } from '~/i18n/utils'
 import schedule from '~/data/schedule.json'
 import { hrefForAgendaSession } from '~/utils/build/agenda/hrefForAgendaSession'
 import { formatHHmm, formatMMdd, compareDate } from '~/utils/datetime'
@@ -9,7 +9,7 @@ import AvatarImage from '~/components/AvatarImage.astro'
 
 const locale = getLocaleFromPath(Astro.url.pathname)
 
-const isZhTW = locale === 'zh-tw'
+const isZhTW = isMandarinPreferred(locale)
 
 const { speaker } = Astro.props
 

--- a/src/i18n/messages/hak-tw.json
+++ b/src/i18n/messages/hak-tw.json
@@ -1,0 +1,139 @@
+{
+  "common": {
+    "dates": {
+      "2": {
+        "title": "徵件結束"
+      }
+    }
+  },
+  "date": {
+    "days": "日"
+  },
+  "meta": {
+    "description": "g0v Summit 2026 係 g0v 台灣零時政府社群兩年一擺个大聚會，乜係全球公民科技、公民行動、開放資料、數位治理實踐者聚到共下个盛會。無論你係想愛來傳承經驗抑係尋人共下打拚，歡迎你來拉張凳仔、擲出索仔，共下來這場公民party！"
+  },
+  "language": {
+    "zh": "中國話",
+    "en": "英國話",
+    "nan": "學老話",
+    "hak": "客話"
+  },
+  "nav": {
+    "venue": "場地同攤位"
+  },
+  "footer": {
+    "pastSites": "逐年網站"
+  },
+  "agenda": {
+    "info": "議程表同講者資訊還在該更新當中，請以年會公告為主。",
+    "qa": "線頂提問",
+    "search_keyword": "用關鍵字來尋議程",
+    "dont_miss": "敢想愛記下議程？",
+    "opass_info": "你做得在開源个 OPass App（iOS / Android）頂項拿著摎年會有關个全部資訊，毋單淨做得先規劃想愛聽个議程，乜會在時間就愛到个時節提供通知。",
+    "has_installed_opass": "既經安裝 OPass?",
+    "open_in_app": "在 App 裡背開啟~"
+  },
+  "visit": {
+    "info": {
+      "mapView": "撳落去來互動"
+    },
+    "transport": {
+      "tabs": {
+        "drivingLine1": "自家駛車",
+        "drivingLine2": "抑係騎車"
+      },
+      "publicTransportStep1": {
+        "title": "1. 移動到南港",
+        "item1": "坐<a href=\"https://www.railway.gov.tw/tra-tip-web/tip/tip00H/tipH41/viewStaInfo/0980\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\">台鐵</a>、<a href=\"https://www.thsrc.com.tw/ArticleContent/2f940836-cedc-41ef-8e28-c2336ac8fe68\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\">高鐵</a>到南港站。",
+        "item2": "坐<a href=\"https://www.metro.taipei/\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\">台北捷運</a>到南港站（板南線）、南港展覽館站（板南線、文湖線）。"
+      },
+      "publicTransportStep2": {
+        "title": "2. 移動到中研院",
+        "item1": "年會接駁車逐日朝晨 7:50 到 9:30 來回行駛<a href=\"https://maps.app.goo.gl/npaRb5tB9zpv8mYU8\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\">台鐵南港站</a> ↔ <a href=\"https://maps.app.goo.gl/SjMNHSzr76wUS1Mx7\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\">中央研究院人文社會科學館北側</a>，請留意現場擎指示牌个工作人員；來回班距大約 20 分鐘，請挷早來等車。",
+        "item2": "在捷運南港站（2 號出口）換坐公車 <a href=\"https://ebus.gov.taipei/Route/StopsOfRoute?routeid=0100021230\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\">212直</a>、<a href=\"https://ebus.gov.taipei/Route/StopsOfRoute?routeid=0100027000\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\">270 </a>抑係<a href=\"https://ebus.gov.taipei/Route/StopsOfRoute?routeid=0112002500\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\"> 藍25</a> 到中研院站。",
+        "item3": "在南港展覽館站（5 號出口）換坐公車 212、276、306、620、645、679、205、小5、小1 或 小12 到中研院站。",
+        "item4": "行路抑係騎自行車<a href=\"https://www.youbike.com.tw/region/taipei/stations/\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-info-dark\"> YouBike </a>到中央研究院人文社會科學館。"
+      },
+      "drivingStep1": {
+        "title": "1. 駛車路線"
+      },
+      "drivingStep3": {
+        "title": "3. 機車停車",
+        "item1": "機車做毋得騎入去中研院，請停在中研院大門右手片、四分溪旁脣个側門、抑係胡適公園邊項个機車停車場。"
+      }
+    }
+  },
+  "cookieNotice": "本網站使用 cookiest 在廣告、社群同分析這兜用途，來增進您你个使用體驗，繼續使用本網站就代表你同意使用 cookies。",
+  "index": {
+    "interact": "用若个雙指來互動",
+    "opening_in": "離開幕還有",
+    "key": {
+      "reset": "擺好凳仔",
+      "ticket": "買票",
+      "pangolin": "射出鰱鯉"
+    },
+    "intro": {
+      "title": "「反客為主个草索幾何學！」",
+      "p1": "有人講，「一朝被蛇咬，十年怕草繩。」但係在 g0v Summit 2026，𠊎兜講「十年<ruby>拍<rp>（</rp><rt lang=\"nan-tw\">phah</rt><rp>）</rp></ruby>草繩」。",
+      "p2": "<strong>對 g0v Summit 2026 來講，這條「草繩」，乜象徵 g0v 十年黑客行動主義精神个具體展現：「莫問仰會無人做這个，先承認你就係『無人』」。因為，「無人」係萬能个。</strong>",
+      "p3": "<strong>毋會坐等、毋會偎凴，𠊎等「反客為主」，自家動手創造：</strong>",
+      "p4": "在這位，g0v Summit 2026 邀請你行入來一隻用草繩編織出來个立體公民座標。",
+      "p5": "你同逐儕參與者因爭逐儕無共樣个技能、價值觀、立場，都係這空間當中个一隻「點」。<br>𠊎兜擲出手項个索仔个時節，摎其他人對話，點就連啊做「線」；<br>盡多條線交織到共下个時節，𠊎等就做起了「面」——這係一張有淰淰動能个行動網絡，乜係一張接等大家个吊床。",
+      "p6": "<strong>故所，原本孤栖个節點形成了聚落，單線个對話演化做協作个生態系。</strong>",
+      "p7": "<strong>對最一開始个「資訊透明、開放成果、開放協作」核心，演化做 g0v Summit 2026 用社群編織出个「公民座標」，同三大座標軸線：（開放透明，自主隱私）、（思辨監督，韌性連結）、（政府體制，民間草根）。</strong>",
+      "p8": "在這位，無人係局外人，逐儕人都能做得找尋著自家个座標，對裡背探索，對外背連結。"
+    },
+    "venue": {
+      "title": "地點"
+    },
+    "g0vSummit": {
+      "title": "麼个係 g0v Summit？",
+      "p1": "對 2012 年開始，<a href=\"https://g0v.tw\" target=\"_blank\">g0v.tw</a> 台灣零時政府社群在「寫程式改造社會」个號召之下，用<b>「資訊透明、開放成果、開放協作」</b>作為核心，透過「群眾草根」个力量關心公共事務，開啟了一場有十過年長个公民黑客實踐。",
+      "p2": "<b>在 318 運動過後，還在 2014 年舉辦 g0v Summit（啥米）零時政府雙年會，推動開放社群、政府、NGO、學術圈、還有網路鄉民跨界交流。</b>",
+      "p3": "這十幾年來，台灣社會乜識經歷異多民主危機、社會動盪摎極端化，各式各樣像係「分蛇哥咬著」个挫折同危機。",
+      "p4": "面對臺灣社會个傷，來自這方摎對面个威脅，「十年」毋單淨係時間个刻度，還過刻畫出公民社群持續个行動同實踐——係一直摎驚怕轉化做韌性个過程。",
+      "p5": "有人講，「一朝被蛇咬，十年怕草繩。」但係在 g0v Summit 2026，𠊎等講<b>「十年<ruby>拍（phah）</rp></ruby>草繩」</b>，𠊎兜相信群眾草根个力量，大家互相个連結，做得一直摎驚怕个「怕」，轉化做行動个「<ruby>拍（phah）</rp></ruby>」。",
+      "p6": "<ruby>拍結<rp>（phah-kat）</rp></ruby>（打結）毋單淨是係為著䌈緪，更加係為著學曉放鬆——鬆動被動个姿態，鬆動偎凴同驚怕，在危機同毋確定个時代裡背，重新練習「自救」同「互助」个筋肉。",
+      "p7": "𠊎兜無愛接受「怕草繩」个被動同畏縮。顛倒，g0v Summit 2026 希望邀請來到這位个每一儕人，摎衫袖攎起來，伸手拿起該條草索，重新搓洗、亼淨來。故所，𠊎等分支、編織、連結，緊幻化還過創造，「草繩」既經毋係該隻得人驚个幻影了，佢既經變做一隻強韌又有機个社群。"
+    },
+    "pastEvents": "逐年活動",
+    "joinG0v": {
+      "p1": "g0v 係一隻草根式个公民社群，煞猛在該想愛加深公民對社會个貢獻同大眾个連結。透過 g0v 社群，你做得在這位尋著志同道合个伴仔，用草根个方式來實踐你个理念，還過摎成果用開放授權个模式放出來，分較多人做得企到你个成果頂項接等來走。",
+      "p2": "摎 gov 用「零」替代做 g0v，對零開始來思考政府个角色，乜代表數位原生世代對 0 同 1 世界个視野。",
+      "events": "g0v 最近个活動"
+    },
+    "sponsorship": {
+      "content": "係講有贊助意願，請詢問：<a href=\"mailto:sponsorship@summit.g0v.tw\">sponsorship@summit.g0v.tw</a>"
+    },
+    "partners": {
+      "donate": "捐錢贊助"
+    }
+  },
+  "sponsor": {
+    "tiers": {
+      "pioneer": "開路个人",
+      "catalyst": "做事个人",
+      "companion": "共下个伴",
+      "sidekick": "撩落去个伴",
+      "special": "特別承蒙"
+    },
+    "support": {
+      "p1": "g0v Summit 係由志工自主籌辦个非營利活動，「反客為主」係𠊎兜 2026 个主題，希望邀請各位共下拉張凳仔，變做行動个一份子。頂高列出个贊助夥伴係分 g0v Summit 2026 變做可能个重要支持力量。",
+      "p2": "g0v Summit 逐擺活動都偎凴社群个支持同参與。除忒出席議程同活動之外，乜歡迎用贊助个方式支持開放社群个發展。",
+      "p3": "𠊎兜提供各式个合作方案，包涵品牌露出、攤位設置、票券贊助同較多个客製選項，期盼同你共下推進公民科技。",
+      "p4": "贊助同合作詢問，歡迎寄信：sponsorship@summit.g0v.tw",
+      "cta": "自家贊助"
+    },
+    "pastReports": {
+      "title": "逐屆 g0v Summit 報導"
+    }
+  },
+  "venue": {
+    "staffRoom": "工作人員歇睏空間",
+    "description": "g0v Summit 今年在中央研究院人文社會科學館舉辦，做得在<a href=\"./visit\">交通資訊</a>頁面查看去个方式。"
+  },
+  "register": {
+    "cta": "馬上買票",
+    "add_to_calendar": "加到日曆"
+  }
+}

--- a/src/i18n/utils.js
+++ b/src/i18n/utils.js
@@ -1,10 +1,17 @@
 import { i18n } from 'astro:config/server'
 import zhTW from '~/i18n/messages/zh-tw.json'
 import en from '~/i18n/messages/en.json'
+import hakTW from '~/i18n/messages/hak-tw.json'
 
 const PROJECT_NAME = import.meta.env.BASE_URL?.replaceAll(/^\/+|\/+$/g, '')
 const defaultLocale = i18n.defaultLocale
 const locales = i18n.locales
+
+export function isMandarinPreferred(locale) {
+  // theoretically we should only use `zh` in locales ['zh-tw', 'man-tw', 'hak-tw', 'nan-tw']
+  // but we’ll cheat a bit before we introduce any other languages (e.g., `ja`)
+  return locale !== 'en'
+}
 
 export function getLocaleFromPath(pathname) {
   pathname = stripProjectName(pathname)
@@ -26,7 +33,24 @@ function stripProjectName(pathname) {
   return PROJECT_NAME && p.startsWith(`/${PROJECT_NAME}`) ? p.slice(PROJECT_NAME.length + 1) : p
 }
 
-const dict = { 'zh-tw': zhTW, en }
+function derive(base, diff) {
+  let result = { ...base }
+  for (const key in diff) {
+    // Perform deep merge for each layer of diffed object
+    if (typeof diff[key] == 'object') {
+      result[key] = derive(base[key], diff[key])
+    } else {
+      result[key] = diff[key]
+    }
+  }
+  return result
+}
+
+const dict = {
+  'zh-tw': zhTW,
+  en,
+  'hak-tw': derive(zhTW, hakTW)
+}
 export function useI18n(pathname) {
   const locale = getLocaleFromPath(pathname)
   return {

--- a/src/pages/hak-tw/about.astro
+++ b/src/pages/hak-tw/about.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/about.astro'
+---
+
+<Page />

--- a/src/pages/hak-tw/agenda/day1.astro
+++ b/src/pages/hak-tw/agenda/day1.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/agenda/day1.astro'
+---
+
+<Page />

--- a/src/pages/hak-tw/agenda/day2.astro
+++ b/src/pages/hak-tw/agenda/day2.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/agenda/day2.astro'
+---
+
+<Page />

--- a/src/pages/hak-tw/agenda/index.astro
+++ b/src/pages/hak-tw/agenda/index.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/agenda/index.astro'
+---
+
+<Page />

--- a/src/pages/hak-tw/index.astro
+++ b/src/pages/hak-tw/index.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/index.astro'
+---
+
+<Page />

--- a/src/pages/hak-tw/speaker.astro
+++ b/src/pages/hak-tw/speaker.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/speaker.astro'
+---
+
+<Page />

--- a/src/pages/hak-tw/sponsor.astro
+++ b/src/pages/hak-tw/sponsor.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/sponsor.astro'
+---
+
+<Page />

--- a/src/pages/hak-tw/venue.astro
+++ b/src/pages/hak-tw/venue.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/venue.astro'
+---
+
+<Page />

--- a/src/pages/hak-tw/visit.astro
+++ b/src/pages/hak-tw/visit.astro
@@ -1,0 +1,5 @@
+---
+import Page from '~/pages/visit.astro'
+---
+
+<Page />

--- a/src/utils/build/speaker.js
+++ b/src/utils/build/speaker.js
@@ -1,3 +1,5 @@
+import { isMandarinPreferred } from "~/i18n/utils"
+
 const stools = [
   `${import.meta.env.BASE_URL}/img/banner/g0v_stool-nbg-b-s.svg`,
   `${import.meta.env.BASE_URL}/img/banner/g0v_stool-nbg-g-m.svg`,
@@ -13,7 +15,7 @@ function normalizeText(value) {
 }
 
 function getLocalizedSpeakerField(speaker, field, locale) {
-  const isZhTW = locale === 'zh-tw'
+  const isZhTW = isMandarinPreferred(locale)
   const primary = isZhTW ? normalizeText(speaker?.zh?.[field]) : normalizeText(speaker?.en?.[field])
   const fallback = isZhTW ? normalizeText(speaker?.en?.[field]) : normalizeText(speaker?.zh?.[field])
   return primary || fallback
@@ -22,7 +24,7 @@ function getLocalizedSpeakerField(speaker, field, locale) {
 export function getSpeakerProfile(speaker, locale) {
   const name = getLocalizedSpeakerField(speaker, 'name', locale)
   const bio = getLocalizedSpeakerField(speaker, 'bio', locale)
-  const otherName = locale === 'zh-tw' ? normalizeText(speaker?.en?.name) : normalizeText(speaker?.zh?.name)
+  const otherName = isMandarinPreferred(locale) ? normalizeText(speaker?.en?.name) : normalizeText(speaker?.zh?.name)
 
   return {
     name,


### PR DESCRIPTION
客語版的 Summit 網站。

### 新增的功能

- i18n 轉換協作工具（ commit 4e165bd0f522d689a541e7f139c1f3a54d324bcb ，已整合進 `main`）
- 語系延伸功能 `derive()`，讓翻譯的語言版本可以沿用華語，確保翻譯版在更新前不會破字XD
- 判斷是否使用華語的邏輯整理進 `i18n/utils` 裡的 `isMandarinPreferred`，用來取代 `isZhTW`

### 協作過程

這個 PR 先用了轉換工具將 `zh-tw.json` 轉成好編輯協作的純文字檔案（格式類似 `.ini`，但就是簡化版），請客家社的夥伴[用 Google Docs 翻完](https://docs.google.com/document/d/1dog6n3XoY7Uz61FTxEoHUOaazqBiY14NmFM3cUfS1Z0/edit?tab=t.eucfanq0qrii)後，將 `hak-tw.txt` 與 `zh-tw.txt` diff 過、留下客語漢字表達不同之處，最後再轉成 `hak-tw.json`。

感謝臺大客家社的夥伴一天內就幫忙看完華客相異之處、把客語漢字版翻出來！
再麻煩開發小組的各位協助 review 了！